### PR TITLE
Correct labelling and add Isaura information

### DIFF
--- a/labelling/file_labelling.py
+++ b/labelling/file_labelling.py
@@ -16,7 +16,8 @@ def label_file(directory,
                relabel = True,
                binclass = True,
                segclass = True, 
-               Rmax = np.nan):
+               Rmax = np.nan,
+               small_blob_th = 0.1):
     '''
     Function that performs the whole beersheba labelling. Starting from the MC hits, they are labelled in three
     classes (rest, track, blob) and voxelized with the labelling_MC function. Then, with the labelling_beersheba
@@ -67,6 +68,9 @@ def label_file(directory,
     
         Rmax: NaN or FLOAT
     Value to perform the fiducial cut of the hits. If NaN, the cut is not done.
+
+        small_blob_th: FLOAT
+    Threshold for the energy of a group of blob hits to be marked as a small blob.
     
     RETURNS:
         labelled_MC_voxels: DATAFRAME
@@ -92,7 +96,8 @@ def label_file(directory,
                                                             start_bin, 
                                                             blob_ener_loss_th = blob_ener_loss_th, 
                                                             blob_ener_th = blob_ener_th, 
-                                                            Rmax = Rmax)
+                                                            Rmax = Rmax,
+                                                            small_blob_th = small_blob_th)
     
     if binclass and segclass:
         labelled_beersheba = labelling_beersheba(directory, 
@@ -117,7 +122,7 @@ def label_file(directory,
     return labelled_MC_voxels, labelled_MC_hits, labelled_beersheba
 
 
-def create_final_dataframes(label_file_dfs, start_id, directory, total_size, voxel_size, start_bin, Rmax = np.nan): 
+def create_final_dataframes(label_file_dfs, start_id, directory, total_size, voxel_size, start_bin, Rmax = np.nan, blob_ener_loss_th = None, blob_ener_th = None, small_blob_th = None): 
     '''
     This function takes the output of label_file function and prepares the data to be saved in a h5 file.
     It will return a dataframe with the bins information of the voxelization of the hits, a dataframe with
@@ -145,6 +150,19 @@ def create_final_dataframes(label_file_dfs, start_id, directory, total_size, vox
     
         start_bin: TUPLE
     Contains the first voxel position for each coordinate.
+
+        Rmax: FLOAT
+    Value for the fiducial cut.
+
+        blob_ener_loss_th: FLOAT
+    Threshold for the last hits of a track to become blob regarding the percentage of energy lost out of 
+    its total energy.
+
+        blob_ener_th: FLOAT
+    Threshold for the last hits of a track to become blob regarding a fixed value of energy.
+
+        small_blob_th: FLOAT
+    Threshold for the energy of a group of blob hits to be marked as a small blob.
     
     RETURNS:
         labelled_MC_voxels: DATAFRAME
@@ -211,7 +229,10 @@ def create_final_dataframes(label_file_dfs, start_id, directory, total_size, vox
                           'size_z'  : size_z,
                           'max_z'   : max_z,
                           'nbins_z' : nbins_z,
-                          'Rmax'    : Rmax
+                          'Rmax'    : Rmax,
+                          'loss_th' : blob_ener_loss_th,
+                          'ener_th' : blob_ener_th,
+                          'sb_th'   : small_blob_th
                           }).to_frame().T
     
     return labelled_MC_voxels, labelled_MC_hits, labelled_beersheba, eventInfo, binsInfo

--- a/scripts/create_labelled_dataset.py
+++ b/scripts/create_labelled_dataset.py
@@ -6,23 +6,27 @@ This script creates hdf5 files that contains:
  - DATASET/BeershebaVoxels - voxelized beersheba hits table with segmentation labels
  - DATASET/EventsInfo      - table that contains EventID, source directory and  binary classification label
  - DATASET/BinInfo         - table that stores info about bins
+ - DATASET/IsauraInfo      - if added, table that contains the isaura tracks info
 
 It takes a CONFIG FILE with the following information:
- - files_in   - string with the beersheba files we want to label
- - file_out   - string with the name of the output file that will contain all the labelled data from the input files
- - total_size - tuple with the size of the detector for each coordinate (in mm), the hits outside this margins will 
-                not be processed
- - voxel_size - tuple with the size of the voxels for each coordinate (in mm)
- - start_bin  - tuple with the  min position of the hits for each coordinate (in mm)
+ - files_in              - string with the beersheba files we want to label
+ - file_out              - string with the name of the output file that will contain all the labelled data from the input files
+ - total_size            - tuple with the size of the detector for each coordinate (in mm), the hits outside this margins will 
+                           not be processed
+ - voxel_size            - tuple with the size of the voxels for each coordinate (in mm)
+ - start_bin             - tuple with the  min position of the hits for each coordinate (in mm)
  - label_neighbours_name - string with the name of the neighbour labelling method
- - blob_ener_loss_th - threshold for the main blob class labelling (in terms of percentage of loss energy at the end
-                       of the track with respect to the total track energy)
- - blob_ener_th - threshold for the main blob class labelling (in terms of absolute energy lost at the end of the track)
- - simple - bool that indicates a way of voxelization for the beersheba hits (not very relevant, for now always True)
- - relabel - bool that indicates if the residual MC voxels are reassigned to an existent beersheba voxel
- - binclass - bool that indicates if the process does the binary labelling
- - segclass - bool that indicates if the process does the segmentation labelling, requires binclass True
- - Rmax - value for the fiducial cut, if NaN the cut is not performed
+ - blob_ener_loss_th     - threshold for the main blob class labelling (in terms of percentage of loss energy at the end
+                           of the track with respect to the total track energy)
+ - blob_ener_th          - threshold for the main blob class labelling (in terms of absolute energy lost at the end of the track)
+ - simple                - bool that indicates a way of voxelization for the beersheba hits (not very relevant, for now always True)
+ - relabel               - bool that indicates if the residual MC voxels are reassigned to an existent beersheba voxel
+ - binclass              - bool that indicates if the process does the binary labelling
+ - segclass              - bool that indicates if the process does the segmentation labelling, requires binclass True
+ - Rmax                  - value for the fiducial cut, if NaN the cut is not performed
+ - small_blob_th         - energy threshold for the blob hits to be marked as small blobs, so the voxelization always represents them
+ - add_isaura_info       - bool that indicates if we want to add the isaura tracks info to the file; we need to have the isaura
+                           files in an analogue directory as the beersheba files_in (that just changes the name of the cities in it)
 """
 
 import sys
@@ -79,23 +83,29 @@ if __name__ == "__main__":
                                     segclass = config.segclass,
                                     Rmax = config.Rmax,
                                     small_blob_th = config.small_blob_th)
-        labelled_MC_voxels, labelled_MC_hits, labelled_beersheba, eventInfo, binsInfo = create_final_dataframes(label_file_dfs,
-                                                                                                                start_id,
-                                                                                                                f,
-                                                                                                                total_size,
-                                                                                                                voxel_size,
-                                                                                                                start_bin,
-                                                                                                                Rmax = config.Rmax,
-                                                                                                                blob_ener_loss_th = config.blob_ener_loss_th,
-                                                                                                                blob_ener_th = config.blob_ener_th,
-                                                                                                                small_blob_th = config.small_blob_th)
+        labelled_MC_voxels, labelled_MC_hits, labelled_beersheba, eventInfo, binsInfo, isauraInfo = create_final_dataframes(label_file_dfs,
+                                                                                                                            start_id,
+                                                                                                                            f,
+                                                                                                                            total_size,
+                                                                                                                            voxel_size,
+                                                                                                                            start_bin,
+                                                                                                                            Rmax = config.Rmax,
+                                                                                                                            blob_ener_loss_th = config.blob_ener_loss_th,
+                                                                                                                            blob_ener_th = config.blob_ener_th,
+                                                                                                                            small_blob_th = config.small_blob_th,
+                                                                                                                            add_isaura_info = config.add_isaura_info)
         start_id +=len(eventInfo)
         with tb.open_file(fileout, 'a') as h5out:
             dio.df_writer(h5out, labelled_MC_hits  , 'DATASET', 'MCHits'         , columns_to_index=['dataset_id'])
             dio.df_writer(h5out, labelled_MC_voxels, 'DATASET', 'MCVoxels'       , columns_to_index=['dataset_id'])
             dio.df_writer(h5out, labelled_beersheba, 'DATASET', 'BeershebaVoxels', columns_to_index=['dataset_id'])
             dio.df_writer(h5out, eventInfo         , 'DATASET', 'EventsInfo'     , columns_to_index=['dataset_id'], str_col_length=128)
-            #dio.df_writer(h5out, binsInfo          , 'DATASET', 'BinsInfo')
+
+            if isauraInfo.empty:
+                pass
+            else:
+                dio.df_writer(h5out, isauraInfo    , 'DATASET', 'IsauraInfo')
+                
         print((time() - start_time)/60, 'mins')
 
     #I try writing here bins info to get only one line in the final dataframe

--- a/scripts/create_labelled_dataset.py
+++ b/scripts/create_labelled_dataset.py
@@ -77,23 +77,30 @@ if __name__ == "__main__":
                                     relabel = config.relabel,
                                     binclass = config.binclass,
                                     segclass = config.segclass,
-                                    Rmax = config.Rmax)
+                                    Rmax = config.Rmax,
+                                    small_blob_th = config.small_blob_th)
         labelled_MC_voxels, labelled_MC_hits, labelled_beersheba, eventInfo, binsInfo = create_final_dataframes(label_file_dfs,
                                                                                                                 start_id,
                                                                                                                 f,
                                                                                                                 total_size,
                                                                                                                 voxel_size,
                                                                                                                 start_bin,
-                                                                                                                Rmax = config.Rmax)
-        binsInfo  = binsInfo.drop(np.arange(1, len(binsInfo), 1), axis = 0)
+                                                                                                                Rmax = config.Rmax,
+                                                                                                                blob_ener_loss_th = config.blob_ener_loss_th,
+                                                                                                                blob_ener_th = config.blob_ener_th,
+                                                                                                                small_blob_th = config.small_blob_th)
         start_id +=len(eventInfo)
         with tb.open_file(fileout, 'a') as h5out:
             dio.df_writer(h5out, labelled_MC_hits  , 'DATASET', 'MCHits'         , columns_to_index=['dataset_id'])
             dio.df_writer(h5out, labelled_MC_voxels, 'DATASET', 'MCVoxels'       , columns_to_index=['dataset_id'])
             dio.df_writer(h5out, labelled_beersheba, 'DATASET', 'BeershebaVoxels', columns_to_index=['dataset_id'])
             dio.df_writer(h5out, eventInfo         , 'DATASET', 'EventsInfo'     , columns_to_index=['dataset_id'], str_col_length=128)
-            dio.df_writer(h5out, binsInfo          , 'DATASET', 'BinsInfo')
+            #dio.df_writer(h5out, binsInfo          , 'DATASET', 'BinsInfo')
         print((time() - start_time)/60, 'mins')
+
+    #I try writing here bins info to get only one line in the final dataframe
+    with tb.open_file(fileout, 'a') as h5out:
+        dio.df_writer(h5out, binsInfo          , 'DATASET', 'BinsInfo')
     #Ahora supuestamente los dfs marcados con columns_to_index con la siguiente función harían que la columna escogida pasara a ser su index
     #Pero creo que no funciona porque usan algo como .attr para sacar los atributos de cada df y yo probé y me dan vacíos, cuando entiendo que
     #deberían ser el columns_to_index para que haga algún cambio (mirar la función en IC para entender a lo que me refiero)

--- a/templates/configTemplate.conf
+++ b/templates/configTemplate.conf
@@ -12,3 +12,5 @@ relabel = True
 binclass = True
 segclass = True
 Rmax = 198
+small_blob_th = 0.1
+add_isaura_info = True

--- a/utils/labelling_utils.py
+++ b/utils/labelling_utils.py
@@ -32,9 +32,9 @@ def add_segclass(mchits, mcpart, delta_loss = None, delta_e = None, label_dict={
     The classes are 1 - rest, 2 - track, 3 - blob.
     Rest class is assigned to every hit that is not in the main tracks. Track class is assigned to the
     hits of the  e- and e+ that come from a gamma conversion process (defined like that in Geant4) in the 
-    double scape case, and to the most energetic e- from a compton scattering proccess. Finally, the blob class
-    is chosen for the last hits of the track events that fulfill a specific condition given either by delta_loss
-    argument of the function or delta_e (explained in the Args part).
+    double scape case, and to the most energetic e- from a compton scattering proccess / photoelectric effect. 
+    Finally, the blob class is chosen for the last hits of the track events that fulfill a specific condition 
+    given either by delta_loss argument of the function or delta_e (explained in the Args part).
     It also computes the distance between the hits of the tracks (we take advantage of the tracks info 
     extraction being done here to perform this calculation)
     

--- a/utils/labelling_utils.py
+++ b/utils/labelling_utils.py
@@ -158,10 +158,11 @@ def add_hits_labels_MC(mchits, mcpart, blob_ener_loss_th = None, blob_ener_th = 
     return hits_clf_seg
 
 
-def voxel_labelling_MC(img, mccoors, mcenes, hits_id, bins):
+def voxel_labelling_MC(img, mccoors, mcenes, hits_id, small_b_mask, bins):
     '''
     This function creates a D-dimensional array that corresponds a voxelized space (we will call it histogram).
-    The bins of this histogram will take the value of the ID hits that deposit more energy within them.
+    The bins of this histogram will take the value of the ID hits that deposit more energy within them, or those
+    marked in the small_b_mask array.
     So, this function takes mainly Monte Carlo hits with a defined segmentation class and voxelizes them.
     
     i.e., in a voxel with several hits, the function will label the voxel as the kind of hit that layed more energy,
@@ -187,6 +188,9 @@ def voxel_labelling_MC(img, mccoors, mcenes, hits_id, bins):
         hits_id: NUMPYARRAY
     IDs for each hit. They define the kind of voxeles we will have. Having N hits, this should be shaped as (N,).
     
+        small_b_mask: NUMPYARRAY
+    Mask for the blob groups of hits with very little energy, so we assure them to appear in the final voxeling
+    
         bins: LIST OF ARRAYS
     D-dim long list, in which each element is an array for a spatial coordinate with the desired bins.
     
@@ -207,8 +211,9 @@ def voxel_labelling_MC(img, mccoors, mcenes, hits_id, bins):
     mc_hit_portion = np.zeros(img.shape)   #array 3d a llenar con el porcentaje de energía de la total que se lleva la partícula más importante
     unique_hits    = np.unique(hits_id)    #lista de identificadores de los hits (identificador puede ser tipo de particula, label, etc...)
     
-    mc_hit_ener    = mcimg(mccoors, mcenes, bins) #histograma de energías 
-
+    mc_hit_ener     = mcimg(mccoors, mcenes, bins) #histograma de energías 
+    small_b_hist, _ = np.histogramdd(mccoors, bins, weights = small_b_mask) #histograma con los hits de blobs pequeños
+    
     #Bucle en los identificadores de los hits para hacer un histograma de energía por tipo de hit
     histograms, nonzero = [], []        #lista de histogramas y de sus coordenadas no nulas
 
@@ -236,10 +241,20 @@ def voxel_labelling_MC(img, mccoors, mcenes, hits_id, bins):
             vox_eners = [] #contenedor de los valores de voxel para todos los histogramas
             for histo in histograms:
                 vox_eners.append(histo[nonzero_coors]) 
-                
+            
             vox_eners = np.array(vox_eners)
             assert len(vox_eners) == len(unique_hits) 
-            selected_id = vox_eners.argmax() #mira la posición del elemento mayor en vox_eners
+            
+            # Ahora debemos escoger la etiqueta del voxel;
+            # Primero miramos si es un blob pequeño, es decir que su posición en el histograma de small_b no sea cero
+            # Si eso se cumple, se asigna a selected_id la posición 2 (que se corresponde con la etiqueta blob)
+            if small_b_hist[nonzero_coors] != 0:
+                selected_id = 2
+                
+            # Si no, mira la posición del elemento mayor en vox_eners
+            else:
+                selected_id = vox_eners.argmax() 
+            
             mc_hit_id[nonzero_coors] = unique_hits[selected_id]   #toma dicha posición de la lista unique_hits y se la asigna a la posición correspondiente en el array vacío 
             
             max_ener   = vox_eners[selected_id]     #energía de la partícula más importante en un voxel 
@@ -287,3 +302,33 @@ def hit_data_cuts(hits, bins, Rmax = np.nan, coords = ['x', 'y', 'z']):
     hits_cut = hits[boundary_cut & fiducial_cut].reset_index(drop = True)
 
     return hits_cut
+
+def add_small_blob_mask(labelled_hits, small_blob_th = 0.1):
+    '''
+    Takes the add_hits_labels_MC output and creates a mask that marks all the small blob hits to make sure 
+    afterwards that they get representation in the voxelization.
+    
+    Args:
+        labelled_hits: DATAFRAME
+    Output of the add_hits_label_MC function.
+    
+        small_blob_th: FLOAT
+    Threshold for the energy of a group of blob hits to become marked.
+    
+    RETURNS:
+        labelled_hits: DATAFRAME
+    The same as in the input, but with a new column called small_b with the mask.
+    '''
+    
+    per_label_info = labelled_hits.groupby(['event_id',
+                                        'particle_id',
+                                        'segclass']).agg({'energy':[('group_ener', sum)]})
+    per_label_info.columns = per_label_info.columns.get_level_values(1)
+    per_label_info.reset_index(inplace=True)
+    
+    sb_mask = ((per_label_info.group_ener < small_blob_th) & (per_label_info.segclass == 3)).values
+    per_label_info['small_b'] = sb_mask
+    
+    labelled_hits = labelled_hits.merge(per_label_info, on = ['event_id', 'particle_id', 'segclass'])
+    
+    return labelled_hits

--- a/utils/labelling_utils.py
+++ b/utils/labelling_utils.py
@@ -88,7 +88,7 @@ def add_segclass(mchits, mcpart, delta_loss = None, delta_e = None, label_dict={
     #Tendremos 1 traza/evento
     tracks_bkg = per_part_info[(per_part_info.event_id.isin(background_event_ids)) &\
                                    (per_part_info.particle_name == 'e-') &\
-                                   (per_part_info.creator_proc  == 'compt')]
+                                   (per_part_info.creator_proc.isin(['compt', 'phot']))]
     
     tracks_bkg = tracks_bkg.loc[tracks_bkg.groupby('event_id').track_ener.idxmax()] #seleccionamos el más energético
     
@@ -130,7 +130,7 @@ def add_segclass(mchits, mcpart, delta_loss = None, delta_e = None, label_dict={
     hits_label_dist = calculate_track_distances(tracks_info, hits_label)
     
     #Escojo solo la información que me interesa
-    hits_label_dist = hits_label_dist[['event_id', 'x', 'y', 'z', 'hit_id', 'energy', 'segclass', 'binclass', 'dist_hits', 'cumdist', 'particle_name', 'creator_proc']].reset_index(drop=True)
+    hits_label_dist = hits_label_dist[['event_id', 'x', 'y', 'z', 'hit_id', 'particle_id',  'energy', 'segclass', 'binclass', 'dist_hits', 'cumdist', 'particle_name', 'creator_proc']].reset_index(drop=True)
     
     return hits_label_dist
 

--- a/utils/labelling_utils.py
+++ b/utils/labelling_utils.py
@@ -247,9 +247,9 @@ def voxel_labelling_MC(img, mccoors, mcenes, hits_id, small_b_mask, bins):
             
             # Ahora debemos escoger la etiqueta del voxel;
             # Primero miramos si es un blob pequeño, es decir que su posición en el histograma de small_b no sea cero
-            # Si eso se cumple, se asigna a selected_id la posición 2 (que se corresponde con la etiqueta blob)
+            # Si eso se cumple, se asigna a selected_id la última posición (que se corresponde con la etiqueta blob)
             if small_b_hist[nonzero_coors] != 0:
-                selected_id = 2
+                selected_id = -1
                 
             # Si no, mira la posición del elemento mayor en vox_eners
             else:


### PR DESCRIPTION
I've improved the basic MC hits labelling process since it failed in some situations:
* For the single electron, I've added photoelectric effect as a possible creation process (its mostly Compton but there are some cases where it's not).
* For the pair production, in the assymetric cases where one of the particles carries most of the energy, I've implemented a small blob marker for the hits. This solves a problem with the voxelization, as these lower energy particles had very low energy blobs and the voxelization would ignore them.

Also, I've added the option to store the Isaura information in the labelling production, as we will need it later for some analysis. 
