### PR TITLE
Change voxel limits

### DIFF
--- a/labelling/MClabelling.py
+++ b/labelling/MClabelling.py
@@ -83,8 +83,10 @@ def labelling_MC(directory, total_size, voxel_size, start_bin, blob_ener_loss_th
     voxelization_df.reset_index()
     
     #Con esto reducimos los voxeles a meros puntos por sencillez, ya que nos deshacemos del tamaño de voxel
+    #y ponemos su origen en 0
     #(el tamaño se tuvo ya en cuenta en la voxelizacion y por tanto ahora esto es indiferente)
-    for coord, size in zip(['x', 'y', 'z'], voxel_size):
+    for coord, (size, start) in zip(['x', 'y', 'z'], zip(voxel_size, start_bin)):
+        voxelization_df[coord] = voxelization_df[coord] - start
         voxelization_df[coord] = voxelization_df[coord] / size
 
     #Hacemos enteras las coord y labels

--- a/labelling/beershebalabelling.py
+++ b/labelling/beershebalabelling.py
@@ -63,7 +63,7 @@ def labelling_beersheba(beersh_dir, total_size, voxel_size, start_bin, labelled_
         #if event_id % 50 == 0:
         #    print(event_id)
     
-        event_neighbours_labelled = label_neighbours_function(df, detector_bins, voxel_size, nlabel_dict)
+        event_neighbours_labelled = label_neighbours_function(df, detector_bins, voxel_size, start_bin, nlabel_dict)
         mc_beersh_voxels = mc_beersh_voxels.merge(event_neighbours_labelled.segclass, 
                                                   left_index = True, 
                                                   right_index = True, 


### PR DESCRIPTION
We want all the voxels to be numbered from 0 to N, being all integers. We can track the real dimensions of the 3D images by the information in BinsInfo. The formula is quite simple:

unitary_bins = (real_bins - min_size) / voxel_size