### PR TITLE
Correct asymmetry

### DIFF
--- a/utils/labelling_utils.py
+++ b/utils/labelling_utils.py
@@ -132,7 +132,7 @@ def add_segclass(mchits, mcpart, delta_loss = None, delta_e = None, label_dict={
     blobless_tracks = tracks_info[missing_blob_mask.values]
 
     #Localizo los hits de esas trazas (que suelen ser muy pocos por cada traza) y los etiqueto todos como blob, así no queda ninguna traza sin blob
-    missing_hits_mask = hits_label[['event_id', 'particle_id']].merge(asym_tracks, how='left', indicator=True)._merge == 'both'
+    missing_hits_mask = hits_label[['event_id', 'particle_id']].merge(blobless_tracks, how='left', indicator=True)._merge == 'both'
     hits_label.loc[(hits_label.segclass==label_dict['track'])& missing_hits_mask.values, 'segclass'] = label_dict['blob']
     
     #Calculo la distancia entre hits de las trazas y lo añado al df de información que tenía


### PR DESCRIPTION
I've changed the hit labelling for segmentation due to some asymmetric events that won't allow certain tracks to have blob marked hits (with the final energy percentage labelling, of course; with the blob energy threshold this problem does not apply, but these changes don't affect this case). Now those tracks that have very few hits are marked as a whole blob, just for keeping the topology information.